### PR TITLE
#23 fix : replace workspace by home directory and replace ng command by ng.cmd …

### DIFF
--- a/packages/klingon-server/terminal.js
+++ b/packages/klingon-server/terminal.js
@@ -56,7 +56,7 @@ app.ws('/cli', (ws, res) => {
         const flags = msg.stdin.split(' ');
         console.log('<<<', flags);
 
-        const child = spawn('ng', flags, {
+        const child = spawn(os.platform() === 'win32' ? 'ng.cmd' : 'ng', flags, {
             cwd: msg.dir || os.homedir(),
             env: process.env
         });

--- a/packages/klingon-ui/package-lock.json
+++ b/packages/klingon-ui/package-lock.json
@@ -3632,6 +3632,7 @@
                     "version": "0.0.9",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "inherits": "~2.0.0"
                     }
@@ -3656,7 +3657,8 @@
                 "buffer-shims": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "caseless": {
                     "version": "0.12.0",
@@ -3673,12 +3675,14 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "combined-stream": {
                     "version": "1.0.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "delayed-stream": "~1.0.0"
                     }
@@ -3691,17 +3695,20 @@
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "cryptiles": {
                     "version": "2.0.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "boom": "2.x.x"
                     }
@@ -3741,7 +3748,8 @@
                 "delayed-stream": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
@@ -3773,7 +3781,8 @@
                 "extsprintf": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "forever-agent": {
                     "version": "0.6.1",
@@ -3896,6 +3905,7 @@
                     "version": "3.1.3",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "boom": "2.x.x",
                         "cryptiles": "2.x.x",
@@ -3943,6 +3953,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3956,7 +3967,8 @@
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "isstream": {
                     "version": "0.1.2",
@@ -4029,12 +4041,14 @@
                 "mime-db": {
                     "version": "1.27.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "mime-types": {
                     "version": "2.1.15",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "mime-db": "~1.27.0"
                     }
@@ -4110,7 +4124,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "oauth-sign": {
                     "version": "0.8.2",
@@ -4168,7 +4183,8 @@
                 "process-nextick-args": {
                     "version": "1.0.7",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "punycode": {
                     "version": "1.4.1",
@@ -4206,6 +4222,7 @@
                     "version": "2.2.9",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "buffer-shims": "~1.0.0",
                         "core-util-is": "~1.0.0",
@@ -4257,7 +4274,8 @@
                 "safe-buffer": {
                     "version": "5.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "semver": {
                     "version": "5.3.0",
@@ -4281,6 +4299,7 @@
                     "version": "1.0.9",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "hoek": "2.x.x"
                     }
@@ -4314,6 +4333,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -4324,6 +4344,7 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.0.1"
                     }
@@ -4352,6 +4373,7 @@
                     "version": "2.2.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "block-stream": "*",
                         "fstream": "^1.0.2",
@@ -4407,7 +4429,8 @@
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "uuid": {
                     "version": "3.0.1",

--- a/packages/klingon-website/package-lock.json
+++ b/packages/klingon-website/package-lock.json
@@ -1295,6 +1295,7 @@
                     "version": "0.0.9",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "inherits": "~2.0.0"
                     }
@@ -1303,6 +1304,7 @@
                     "version": "2.10.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "hoek": "2.x.x"
                     }
@@ -1319,7 +1321,8 @@
                 "buffer-shims": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "caseless": {
                     "version": "0.12.0",
@@ -1336,12 +1339,14 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "combined-stream": {
                     "version": "1.0.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "delayed-stream": "~1.0.0"
                     }
@@ -1354,12 +1359,14 @@
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "cryptiles": {
                     "version": "2.0.5",
@@ -1405,7 +1412,8 @@
                 "delayed-stream": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
@@ -1431,7 +1439,8 @@
                 "extsprintf": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "forever-agent": {
                     "version": "0.6.1",
@@ -1602,6 +1611,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1615,7 +1625,8 @@
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "isstream": {
                     "version": "0.1.2",
@@ -1688,12 +1699,14 @@
                 "mime-db": {
                     "version": "1.27.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "mime-types": {
                     "version": "2.1.15",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "mime-db": "~1.27.0"
                     }
@@ -1767,7 +1780,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "oauth-sign": {
                     "version": "0.8.2",
@@ -1825,7 +1839,8 @@
                 "process-nextick-args": {
                     "version": "1.0.7",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "punycode": {
                     "version": "1.4.1",
@@ -1863,6 +1878,7 @@
                     "version": "2.2.9",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "buffer-shims": "~1.0.0",
                         "core-util-is": "~1.0.0",
@@ -1914,7 +1930,8 @@
                 "safe-buffer": {
                     "version": "5.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "semver": {
                     "version": "5.3.0",
@@ -1972,6 +1989,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -1982,6 +2000,7 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.0.1"
                     }
@@ -2010,6 +2029,7 @@
                     "version": "2.2.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "block-stream": "*",
                         "fstream": "^1.0.2",
@@ -2065,7 +2085,8 @@
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "uuid": {
                     "version": "3.0.1",


### PR DESCRIPTION
replaced workspace by home directory and  ng command by ng.cmd for windows platforms...

Note:  User will have to run vscode as administrator in windows to address following error , "Error launching WinPTY agent: ConnectNamedPipe failed: Windows error 232 at new WindowsPtyAgent "

https://github.com/Microsoft/node-pty/issues/208

Rest issues fixed.