### PR TITLE
fix: update create & flags components to remove deprecated flags

### DIFF
--- a/packages/klingon-ui/src/app/cli/create/create.component.html
+++ b/packages/klingon-ui/src/app/cli/create/create.component.html
@@ -34,10 +34,6 @@
         <mat-hint align="start">The style file default extension</mat-hint>
       </mat-form-field>
       <mat-form-field>
-        <input formControlName="source-dir" matInput placeholder="Source directory">
-        <mat-hint align="start">The name of the source directory.</mat-hint>
-      </mat-form-field>
-      <mat-form-field>
         <input formControlName="directory" matInput placeholder="App directory name">
         <mat-hint align="start">Name of the directory to create the app in, <em>relative</em> to the Project Root Directory. Leave empty to use this Application name</mat-hint>
       </mat-form-field>
@@ -56,13 +52,7 @@
           <mat-checkbox formControlName="inline-template">Should have an inline template</mat-checkbox>
         </mat-list-item>
         <mat-list-item>
-          <mat-checkbox formControlName="minimal">Should create a minimal app</mat-checkbox>
-        </mat-list-item>
-        <mat-list-item>
           <mat-checkbox formControlName="routing">Generate a routing module</mat-checkbox>
-        </mat-list-item>
-        <mat-list-item>
-          <mat-checkbox formControlName="skip-commit">Skip committing the first commit to git</mat-checkbox>
         </mat-list-item>
         <mat-list-item>
           <mat-checkbox formControlName="skip-git">Skip initializing a git repository</mat-checkbox>

--- a/packages/klingon-ui/src/app/cli/flags/flags.component.ts
+++ b/packages/klingon-ui/src/app/cli/flags/flags.component.ts
@@ -1,4 +1,3 @@
-import { browser } from 'protractor';
 import { Validators } from '@angular/forms';
 import { FormControl } from '@angular/forms';
 import { FormGroup } from '@angular/forms';
@@ -55,15 +54,12 @@ export class FlagsComponent implements OnInit {
         'root-dir': new FormControl(lastUsedRootDirectory),
         directory: new FormControl(''),
         prefix: new FormControl('app'),
-        'source-dir': new FormControl('src'),
         style: new FormControl('css'),
         verbose: new FormControl(false),
         'inline-style': new FormControl(false),
         'inline-template': new FormControl(false),
         'dry-run': new FormControl(false),
-        minimal: new FormControl(false),
         routing: new FormControl(false),
-        'skip-commit': new FormControl(false),
         'skip-git': new FormControl(false),
         'skip-install': new FormControl(false),
         'skip-tests': new FormControl(false)


### PR DESCRIPTION
It removes the following deprecated flags:
- minimal
- skip-commit
- source-dir

It also removes an unused import (browser)