### PR TITLE
fix(klingonApp): service worker script breaks in electron in production mode, klingon logo url broken

### DIFF
--- a/packages/klingon-app/main.js
+++ b/packages/klingon-app/main.js
@@ -8,30 +8,49 @@ const isDev = process.env.KLINGON_ENV === 'DEV';
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;
-
 function createWindow() {
-  let url = isDev ? 'http://localhost:4200' : `file://${__dirname}/dist-ui/index.html`;
+  let appUrl = isDev ? 'http://localhost:4200' : `file://${__dirname}/dist-ui/index.html`;
+  const PROTOCOL = 'file';
+  mainWindow = new BrowserWindow({ width: 1024, height: 768, webPreferences: { webSecurity: false } });
 
-  mainWindow = new BrowserWindow({ width: 1024, height: 768 });
+  mainWindow.on('closed', function () {
+    mainWindow = null;
+  });
 
-  mainWindow.loadURL(url);
+  mainWindow.on('ready', function (e) {
+  });
+
+  /**
+   * Handle "Request scheme 'file' is unsupported" error
+   */
+  electron.protocol.interceptFileProtocol(PROTOCOL, (request, callback) => {
+    // Strip protocol
+
+    let url = request.url.substr(PROTOCOL.length + 1);
+
+    // Build complete path for node require function
+    url = path.join('', '', url);
+
+    // Replace backslashes by forward slashes (windows)
+    url = process.platform === 'win32' ? url.replace(/\\/g, '/') : path.normalize(url);
+
+    callback({ path: url });
+  });
+
+  mainWindow.loadURL(appUrl);
 
   if (isDev) {
     mainWindow.webContents.openDevTools();
   }
-
-  mainWindow.on('closed', function() {
-    mainWindow = null;
-  });
 }
 
 app.on('ready', createWindow);
 
-app.on('window-all-closed', function() {
+app.on('window-all-closed', function () {
   app.quit();
 });
 
-app.on('activate', function() {
+app.on('activate', function () {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {

--- a/packages/klingon-app/renderer.js
+++ b/packages/klingon-app/renderer.js
@@ -1,3 +1,11 @@
 // This file is required by the index.html file and will
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
+
+/**
+ * Handle following error:-
+ * Fetch API cannot load <url>. URL scheme "file" is not supported.
+ * */
+const electron = require('electron');
+electron.webFrame.registerURLSchemeAsPrivileged('file');
+

--- a/packages/klingon-ui/src/app/app.component.css
+++ b/packages/klingon-ui/src/app/app.component.css
@@ -1,7 +1,7 @@
 :host mat-toolbar {
     height: 149px;
     position: fixed;
-    background-image: url('/assets/ngKlingon__white.png');
+    background-image: url('../assets/ngKlingon__white.png');
     background-size: 90px;
     background-repeat: no-repeat;
     background-position: center top;


### PR DESCRIPTION


Fixes following error:
1) Fetch API cannot load <url>. URL scheme "file" is not supported.
2) Request scheme 'file' is unsupported
3) assets/ngKlingon__white.png File Not Found

Fixes #64